### PR TITLE
Fix snowball

### DIFF
--- a/R/oa_snowball.R
+++ b/R/oa_snowball.R
@@ -21,7 +21,7 @@
 oa_snowball <- function(
                      identifier = NULL, ## identifier of a work, author, venue, etc.
                      output = c("tibble", "dataframe"),
-                     mailto = NULL,
+                     mailto = oa_email(),
                      endpoint = "https://api.openalex.org/",
                      verbose = FALSE) {
   output <- match.arg(output)
@@ -67,6 +67,8 @@ for (i in 1:length(list_CR)){
 cited<- do.call(rbind,cited)
 
 # merging all documents in a single data frame
+if (is.null(citing)) citing <- paper[0, TRUE]
+
 citing$role <- "citing"
 cited$role <- "cited"
 paper$role <- "target"

--- a/R/oa_snowball.R
+++ b/R/oa_snowball.R
@@ -18,64 +18,62 @@
 #'   verbose = TRUE
 #' )
 #' }
-oa_snowball <- function(
-                     identifier = NULL, ## identifier of a work, author, venue, etc.
-                     output = c("tibble", "dataframe"),
-                     mailto = oa_email(),
-                     endpoint = "https://api.openalex.org/",
-                     verbose = FALSE) {
+oa_snowball <- function(identifier = NULL, ## identifier of a work, author, venue, etc.
+                        output = c("tibble", "dataframe"),
+                        mailto = oa_email(),
+                        endpoint = "https://api.openalex.org/",
+                        verbose = FALSE) {
   output <- match.arg(output)
 
   if (output == "dataframe") output <- "tibble"
 
-# fetching all documents citing the target papers
-  if (isTRUE(verbose)) message("Collecting all documents citing the target papers")
-citing <- oa_fetch(
-  entity = "works",
-  cites = identifier,
-  output = output,
-  endpoint = endpoint,
-  mailto = mailto,
-  verbose = verbose
-)
+  # fetching all documents citing the target papers
+  if (verbose) message("Collecting all documents citing the target papers")
 
-# collecting the reference lists of the target papers
-paper <- oa_fetch(
-  entity = "works",
-  identifier = identifier,
-  output = output,
-  endpoint = endpoint,
-  mailto = mailto,
-  verbose = verbose
-)
-
-# fetching all documents cited by the target papers
-CR <- unique(unlist(paper$referenced_works))
-list_CR <- split(CR, ceiling(seq_along(CR)/50))
-cited <- list()
-if (isTRUE(verbose)) message("Collecting all documents cited by the target papers")
-for (i in 1:length(list_CR)){
-  cited[[i]] <- oa_fetch(
+  citing <- oa_fetch(
     entity = "works",
-    identifier = list_CR[[i]],
+    cites = identifier,
     output = output,
     endpoint = endpoint,
     mailto = mailto,
     verbose = verbose
   )
+
+  # collecting the reference lists of the target papers
+  paper <- oa_fetch(
+    entity = "works",
+    identifier = identifier,
+    output = output,
+    endpoint = endpoint,
+    mailto = mailto,
+    verbose = verbose
+  )
+
+  # fetching all documents cited by the target papers
+  CR <- unique(unlist(paper$referenced_works))
+  list_CR <- split(CR, ceiling(seq_along(CR) / 50))
+
+  if (verbose) message("Collecting all documents cited by the target papers")
+
+  cited <- list()
+  for (i in seq_along(list_CR)) {
+    cited[[i]] <- oa_fetch(
+      entity = "works",
+      identifier = list_CR[[i]],
+      output = output,
+      endpoint = endpoint,
+      mailto = mailto,
+      verbose = verbose
+    )
+  }
+  cited <- do.call(rbind, cited)
+
+  # merging all documents in a single data frame
+  if (is.null(citing)) citing <- paper[0, TRUE]
+
+  citing$role <- "citing"
+  cited$role <- "cited"
+  paper$role <- "target"
+
+  rbind(citing, cited, paper)
 }
-cited<- do.call(rbind,cited)
-
-# merging all documents in a single data frame
-if (is.null(citing)) citing <- paper[0, TRUE]
-
-citing$role <- "citing"
-cited$role <- "cited"
-paper$role <- "target"
-df <- rbind(citing,cited, paper)
-
-return(df)
-}
-
-
-

--- a/man/oa_snowball.Rd
+++ b/man/oa_snowball.Rd
@@ -8,7 +8,7 @@ and convert the result to a tibble/data frame.}
 oa_snowball(
   identifier = NULL,
   output = c("tibble", "dataframe"),
-  mailto = NULL,
+  mailto = oa_email(),
   endpoint = "https://api.openalex.org/",
   verbose = FALSE
 )

--- a/tests/testthat/test-oa_snowball.R
+++ b/tests/testthat/test-oa_snowball.R
@@ -1,4 +1,4 @@
-test_that("oa_snowball", {
+test_that("oa_snowball works", {
   work_ids <- c("W2741809807")
   multi_works <- oa_snowball(
     identifier = work_ids,
@@ -8,5 +8,13 @@ test_that("oa_snowball", {
     multi_works$id[multi_works$role=="target"],
     paste0("https://openalex.org/", work_ids)
   )
+
+  snowball_docs <- oa_snowball(
+    identifier = c("W4295757800", "W4296128995", "W4297497355"),
+    endpoint = "https://api.openalex.org/",
+    verbose = TRUE
+  )
+
+  expect_true(is.data.frame(snowball_docs))
 
 })


### PR DESCRIPTION
`oa_snowball` no longer errors out when a work hasn't been cited.

``` r
library(openalexR)

snowball_docs <- oa_snowball(
  identifier = c("W4295757800", "W4296128995", "W4297497355"),
  endpoint = "https://api.openalex.org/",
  verbose = FALSE
)
#> the list does not contain a valid OpenAlex collection

head(snowball_docs)
#> # A tibble: 6 × 27
#>   id        displ…¹ author ab    publi…² relev…³ so    so_id publi…⁴ issn  url  
#>   <chr>     <chr>   <list> <chr> <chr>   <lgl>   <chr> <chr> <chr>   <lis> <chr>
#> 1 https://… Deep R… <df>   Deep… 2016-0… NA      2016… <NA>  IEEE    <lgl> http…
#> 2 https://… SWISS-… <df>   Homo… 2018-0… NA      Nucl… http… Oxford… <chr> http…
#> 3 https://… Molecu… <df>   Oral… 2002-0… NA      Jour… http… Americ… <chr> http…
#> 4 https://… Highly… <df>   Prot… 2021-0… NA      Natu… http… Spring… <chr> http…
#> 5 https://… Extend… <df>   Exte… 2010-0… NA      Jour… http… Americ… <chr> http…
#> 6 https://… ChEMBL… <df>   ChEM… 2012-0… NA      Nucl… http… Oxford… <chr> http…
#> # … with 16 more variables: first_page <chr>, last_page <chr>, volume <chr>,
#> #   issue <chr>, is_oa <lgl>, cited_by_count <int>, counts_by_year <list>,
#> #   publication_year <int>, cited_by_api_url <chr>, ids <list>, doi <chr>,
#> #   type <chr>, referenced_works <list>, related_works <list>, concepts <list>,
#> #   role <chr>, and abbreviated variable names ¹​display_name,
#> #   ²​publication_date, ³​relevance_score, ⁴​publisher
```

<sup>Created on 2022-09-30 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>