### PR TITLE
Slightly modify to_disk

### DIFF
--- a/R/oa_snowball.R
+++ b/R/oa_snowball.R
@@ -124,7 +124,20 @@ oa_snowball <- function(identifier = NULL,
 #'
 #' @param snowball List result from `oa_snowball`.
 #'
-#' @return Tibble/data.frame of works with additional `cited_by` column.
+#' @return Tibble/data.frame of works with additional columns:
+#' append `citing`, `backward_count`, `cited_by`, `forward_count`, `connection`,
+#' and `connection_count.` For each work/row, these counts are WITHIN one
+#' snowball search, and so `forward_count` <= `cited_by_count`.
+#'
+#' Consider the universe of all works linked to a set of starting works, (`oa_input = TRUE`)
+#' for each work/row i:
+#' - citing: works in the universe that i cites
+#' - backward_count: number of works in the universe that i cites
+#' - cited_by: works that i is cited by
+#' - forward_count: number of works in the universe that i is cited by
+#' - connection: works in the universe linked to i
+#' - connection_count: number of works in the universe linked to i (degree of i)
+#'
 #' @export
 #'
 #' @examples
@@ -146,8 +159,8 @@ to_disk <- function(snowball) {
     function(x) {
       list(
         id = unique(x$from),
-        backward_count = nrow(x),
-        citing = paste(x$to, collapse = ";")
+        citing = paste(x$to, collapse = ";"),
+        backward_count = nrow(x)
       )
     }
   ))
@@ -157,8 +170,8 @@ to_disk <- function(snowball) {
     function(x) {
       list(
         id = unique(x$to),
-        forward_count = nrow(x),
-        cited_by = paste(x$from, collapse = ";")
+        cited_by = paste(x$from, collapse = ";"),
+        forward_count = nrow(x)
       )
     }
   ))

--- a/man/to_disk.Rd
+++ b/man/to_disk.Rd
@@ -10,7 +10,19 @@ to_disk(snowball)
 \item{snowball}{List result from `oa_snowball`.}
 }
 \value{
-Tibble/data.frame of works with additional `cited_by` column.
+Tibble/data.frame of works with additional columns:
+append `citing`, `backward_count`, `cited_by`, `forward_count`, `connection`,
+and `connection_count.` For each work/row, these counts are WITHIN one
+snowball search, and so `forward_count` <= `cited_by_count`.
+
+Consider the universe of all works linked to a set of starting works, (`oa_input = TRUE`)
+for each work/row i:
+- citing: works in the universe that i cites
+- backward_count: number of works in the universe that i cites
+- cited_by: works that i is cited by
+- forward_count: number of works in the universe that i is cited by
+- connection: works in the universe linked to i
+- connection_count: number of works in the universe linked to i (degree of i)
 }
 \description{
 |  id|title |...|cited_by_count| referenced_works   |cited_by |...|
@@ -25,6 +37,6 @@ flat_snow <- to_disk(oa_snowball(
   verbose = TRUE
 ))
 
-flat_snow[, c("id", "cited_by")]
+flat_snow[, c("id", "connection", "connection_count")]
 }
 }

--- a/tests/testthat/test-oa_snowball.R
+++ b/tests/testthat/test-oa_snowball.R
@@ -15,8 +15,13 @@ test_that("oa_snowball works", {
   )
 
   expect_equal(nrow(flat_snow), nrow(multi_nodes))
-  expect_equal(ncol(flat_snow), ncol(multi_nodes) + 1)
-  expect_true("cited_by" %in% names(flat_snow))
+  expect_equal(ncol(flat_snow), ncol(multi_nodes) + 6)
+  expect_true(all(
+    c("cited_by", "citing", "connection",
+      "forward_count", "backward_count", "connection_count") %in%
+      names(flat_snow)
+  ))
+
   expect_s3_class(flat_snow, "data.frame")
 })
 


### PR DESCRIPTION
addresses #23

- [x] modify `to_disk`: no longer depends on dplyr, append citing, backward_count, cited_by, forward_count, connection, and connection_count as columns in the final output
- [x] small fix in oa_snowball

``` r
library(openalexR)
flat_snow <- to_disk(oa_snowball(
  identifier = "W1516819724",
  verbose = TRUE
))
#> Requesting url: https://api.openalex.org/works/W1516819724
#> Collecting all documents citing the target papers...
#> Requesting url: https://api.openalex.org/works?filter=cites%3AW1516819724
#> About to get a total of 1 pages of results with a total of 4 records.
#> Collecting all documents cited by the target papers...
#> Requesting url: https://api.openalex.org/works?filter=cited_by%3AW1516819724
#> One list does not contain a valid OpenAlex collection

flat_snow[, c("id", "connection", "connection_count")]
#>            id                                      connection connection_count
#> 1 W1516819724 W2613880959;W2579547421;W2251756894;W3045921891                4
#> 2 W2251756894                                     W1516819724                1
#> 3 W2579547421                                     W1516819724                1
#> 4 W2613880959                                     W1516819724                1
#> 5 W3045921891                                     W1516819724                1
```

<sup>Created on 2022-10-06 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>