### PR TITLE
Handle empty author

### DIFF
--- a/R/oa2df.R
+++ b/R/oa2df.R
@@ -179,7 +179,7 @@ works2df <- function(data, abstract = TRUE, verbose = TRUE) {
       }
       first_inst <- prepend(first_inst, "institution")
       aff_raw <- list(au_affiliation_raw = l$raw_affiliation_string[1])
-      l_author <- prepend(l$author, "au")
+      l_author <- if (length(l$author) > 0) prepend(l$author, "au") else list()
       c(l_author, l["author_position"], aff_raw, first_inst)
     })))
 


### PR DESCRIPTION
Closes #36.

I pinpointed it to W4206756298 where the `authorships$author` field is an empty named list.

``` r
library(openalexR)
oa_fetch("W4206756298")
#> # A tibble: 1 × 28
#>   id        displ…¹ author ab    publi…² relev…³ so    so_id publi…⁴ issn  url  
#>   <chr>     <chr>   <list> <lgl> <chr>   <lgl>   <chr> <chr> <chr>   <lis> <chr>
#> 1 https://… Transm… <df>   NA    1997-0… NA      The … http… New En… <chr> http…
#> # … with 17 more variables: first_page <chr>, last_page <chr>, volume <chr>,
#> #   issue <chr>, is_oa <lgl>, cited_by_count <int>, counts_by_year <list>,
#> #   publication_year <int>, cited_by_api_url <chr>, ids <list>, doi <chr>,
#> #   type <chr>, referenced_works <list>, related_works <list>,
#> #   is_paratext <lgl>, is_retracted <lgl>, concepts <list>, and abbreviated
#> #   variable names ¹​display_name, ²​publication_date, ³​relevance_score,
#> #   ⁴​publisher
```

<sup>Created on 2022-10-19 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>