### PR TITLE
na.omit to fix #51

### DIFF
--- a/R/oa_snowball.R
+++ b/R/oa_snowball.R
@@ -95,7 +95,7 @@ oa_snowball <- function(identifier = NULL,
   # remove duplicates when two input identifiers cite each other
   edges <- edges[!duplicated(edges), ]
   # remove edges to/from NA nodes
-  edges <- na.omit(edges)
+  edges <- edges[complete.cases(edges), ]
 
   if (id_type == "short") {
     edges$to <- shorten_oaid(edges$to)

--- a/R/oa_snowball.R
+++ b/R/oa_snowball.R
@@ -94,6 +94,8 @@ oa_snowball <- function(identifier = NULL,
   edges <- rbind(citing_rel, cited_rel)
   # remove duplicates when two input identifiers cite each other
   edges <- edges[!duplicated(edges), ]
+  # remove edges to/from NA nodes
+  edges <- na.omit(edges)
 
   if (id_type == "short") {
     edges$to <- shorten_oaid(edges$to)


### PR DESCRIPTION
Just wraps `$edges` in `na.omit()` before returning from `oa_snowball()`.

```r
devtools::load_all()

set <- c("W1992473459", "W4246185059", "W3119850932")
snowballed <- oa_snowball(set) # finds ~200 papers

anyNA(snowballed$edges)
# [1] FALSE
```