### PR TITLE
Type handling for the `concepts` list-column of `"works"` entity

### DIFF
--- a/R/oa2df.R
+++ b/R/oa2df.R
@@ -166,6 +166,17 @@ works2df <- function(data, abstract = TRUE, verbose = TRUE) {
       type = "rbind_df"
     )
 
+    # Type conversions for concepts df
+    sub_rbind_dfs$concepts <- lapply(sub_rbind_dfs$concepts, function(x) {
+      if (is.atomic(x) && is.na(x)) {
+        NULL
+      } else if (!is.null(x$score)) {
+        transform(x, score = as.double(score))
+      } else {
+        x
+      }
+    })
+
     sub_venue <- setNames(paper$host_venue[venue_cols], names(venue_cols))
     sub_venue$issn <- subs_na(paper$host_venue$issn, "flat")
 


### PR DESCRIPTION
Adds a step after the conversion of `$concepts` from list to df, to ensure that missingness is encoded as `NULL` (#56) and the `score` column is double when it exists (#57).

```r
papers <- oa_fetch(c("W2755950973", "W4296015844"), "works")

# Missing concepts are `NULL` in the `$concepts` list-column
papers$concepts
#> [[1]]
#>                                 id                               wikidata     display_name level     score
#> 1   https://openalex.org/C41008148   https://www.wikidata.org/wiki/Q21198 Computer science     0 0.6361582
#> 2 https://openalex.org/C2522767166 https://www.wikidata.org/wiki/Q2374463     Data science     1 0.3629617
#> 
#> [[2]]
#> NULL

# `$concepts$score` is parsed as double when it exists
typeof( papers$concepts[[1]]$score )
#> [1] "double"
```