### PR TITLE
`oa_ngrams` speed up with new `{curl}` v5.0.0

### DIFF
--- a/R/oa_ngrams.R
+++ b/R/oa_ngrams.R
@@ -72,6 +72,7 @@ oa_ngrams <- function(works_identifier, ..., verbose = FALSE) {
         ngram2df(jsonlite::fromJSON(x))
       }
     })
+    file.remove(ngrams_files$destfile)
   } else {
     # One-time message
     if (getOption("oa_ngrams.message.curlv5", TRUE)) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -374,8 +374,7 @@ ngrams_data |>
   )
 ```
 
-`oa_ngrams` can sometimes be slow because the N-grams data can get pretty big, but given that the N-grams are `"cached via CDN"`](https://docs.openalex.org/api-entities/works/get-n-grams#api-endpoint), you may also consider parallelizing for this special case.
-
+`oa_ngrams` can sometimes be slow because the N-grams data can get pretty big, but given that the N-grams are `"cached via CDN"`](https://docs.openalex.org/api-entities/works/get-n-grams#api-endpoint), you may also consider parallelizing for this special case (`oa_ngrams` does this automatically if you have `{curl} >= v5.0.0`).
 
 ## About OpenAlex
 

--- a/man/oa_ngrams.Rd
+++ b/man/oa_ngrams.Rd
@@ -8,7 +8,7 @@ oa_ngrams(works_identifier, ..., verbose = FALSE)
 }
 \arguments{
 \item{works_identifier}{Character. OpenAlex ID(s) of "works" entities as item identifier(s).
-These IDs normally start with "W". See more at <https://docs.openalex.org/about-the-data/work#id>.}
+These IDs start with "W". See more at <https://docs.openalex.org/about-the-data/work#id>.}
 
 \item{...}{Unused.}
 
@@ -23,6 +23,10 @@ Some work entities in OpenAlex include N-grams (word sequences and their frequen
 The N-grams are obtained from Internet Archive, which uses the spaCy parser to index scholarly works.
 See <https://docs.openalex.org/api/get-n-grams> for coverage and more technical details.
 }
+\note{
+A faster implementation is available for `curl` >= v5.0.0, and `oa_ngrams` will issue a one-time message
+about this. This can be suppressed with `options("oa_ngrams.message.curlv5" = FALSE)`.
+}
 \examples{
 \dontrun{
 
@@ -32,6 +36,9 @@ library(dplyr)
 first_paper_ngrams <- ngrams_data$ngrams[[1]]
 top_10_ngrams <- first_paper_ngrams \%>\%
   slice_max(ngram_count, n = 10, with_ties = FALSE)
+
+# Missing N-grams are `NULL` in the `ngrams` list-column
+oa_ngrams("https://openalex.org/W2284876136")
 
 }
 }


### PR DESCRIPTION
The [new curl release today](https://ropensci.org/blog/2023/01/13/curl5-release/) adds the parallelized `multi_download()` function, which we can use to significantly speed up `oa_ngrams()` which currently requests/parses one-by-one (we can't do a batch request like in `oa_fetch()` because the ngrams API is async and static).

I'm leaving this as a draft until we decide whether we should:
1) Import `curl` >=5.0.0, OR
2) Import `curl` without version spec as we do currently, but use `multi_download()` if pkg version is >=5.0.0

Until we resolve that, the newer/faster version is added to this draft PR as `oa_ngrams2()`:

```r
devtools::load_all()

# Single paper ngram search ####

single <- "W1963991285"

system.time(ngram_single1 <- oa_ngrams(single))
#> user  system elapsed 
#> 0.02    0.01    0.18 
#> 
system.time(ngram_single2 <- oa_ngrams2(single))
#> user  system elapsed 
#> 0.03    0.00    0.17 

identical(ngram_single1, ngram_single2)
#> [1] TRUE


# Many paper ngram search ####

batch <- oa_snowball(single)$nodes$id
length(batch)
#> [1] 348

system.time(ngram_batch1 <- oa_ngrams(batch))
#> user  system elapsed 
#> 10.24    1.75   85.71 

system.time(ngram_batch2 <- oa_ngrams2(batch))
# user  system elapsed 
# 7.82    1.03   13.25 

identical(ngram_batch1, ngram_batch2)
#> [1] TRUE
```
